### PR TITLE
change buttons for site to be smaller and the edit button as an icon

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -28,6 +28,31 @@ html {
   padding: 0;
 }
 
+.site-btn {
+  color: white;
+  background: #6E8FBC;
+  height: auto;
+  width: 80px;
+  border: none;
+}
+
+.site-btn:hover {
+  color: white;
+  background-color: #0275d8; 
+}
+
+.icon-btn {
+  color: #6E8FBC;
+  border: none;
+  background-color: #f5f5f5;
+}
+
+.icon-btn:hover {
+  color: #0275d8;
+  border: none;
+  background-color: #f5f5f5;
+}
+
 .container1 {
   height: 80%;
   display: flex;
@@ -58,7 +83,7 @@ html {
   background-size: 500px;
 }
 
-.btn{
+.home-btn{
   color: white;
   font-size: 30px;
   width: 207px;

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,21 +1,51 @@
 <%= render 'shared/navbar' %>
-<h2>Log in</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: false,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-    <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "current-password" } %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+<!-- <div class="modal fade" id="editInfoModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">Log In</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+          <h2>Log in</h2>
+          <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+            <%= f.input :email,
+              required: false,
+              autofocus: true,
+              input_html: { autocomplete: "email" } %>
+            <%= f.input :password,
+              required: false,
+              input_html: { autocomplete: "current-password" } %>
+            <%= f.submit "Edit", class: "btn" %>
+            <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+            <%= f.button :submit, "Log in" %>
+          <% end %>
+      </div>
+    </div>
   </div>
+</div> -->
 
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
-  </div>
-<% end %>
+
+  <h2>Log in</h2>
+
+  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="form-inputs">
+      <%= f.input :email,
+                  required: false,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" } %>
+      <%= f.input :password,
+                  required: false,
+                  input_html: { autocomplete: "current-password" } %>
+      <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+    </div>
+
+    <div class="form-actions">
+      <%= f.button :submit, "Log in", class: 'site-btn' %>
+    </div>
+  <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="text1">
       <p>Your launchpad for a rewarding career in tech.</p>
-      <%= link_to 'Get Started', new_user_registration_path, class: 'btn' %>
+      <%= link_to 'Get Started', new_user_registration_path, class: 'home-btn' %>
     </div>
   </div>
 

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -24,7 +24,7 @@
                   <%= simple_form_for(@user) do |f| %>
                     <%= f.input :username %>
                     <%= f.input :photo, as: :file %>
-                    <%= f.submit "Edit", class: "btn" %>
+                    <%= f.submit "Edit", class: "site-btn" %>
                   <% end %>
                 </div>
               </div>
@@ -40,8 +40,8 @@
             <h3>Available for hire NOW!</h3>
 
           </div>
-           <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#editInfoModal">
-          Edit User
+           <button type="button" class="site-btn" data-toggle="modal" data-target="#editInfoModal">
+          Update
           </button>
         </div>
 
@@ -88,7 +88,7 @@
               <%= skill.skill_name %>
               <%= skill.level %>
               <%= skill.years_of_experience %>
-              <button type="button" class="btn-modal btn-primary" data-toggle="modal" data-target="#editSkillModal<%= skill.id %>"><i class="fad fa-edit">Edit</i>
+              <button type="button" class="icon-btn" data-toggle="modal" data-target="#editSkillModal<%= skill.id %>"><i class="fa fa-edit"></i>
               </button>
             </div>
           </li>
@@ -110,7 +110,7 @@
                     <%= f.input :skill_name %>
                     <%= f.input :level %>
                     <%= f.input :years_of_experience %>
-                    <%= f.submit "edit skill", class: "btn-edit" %>
+                    <%= f.submit "Update", class: "site-btn" %>
                   <% end %>
                 </div>
               </div>
@@ -134,7 +134,7 @@
                 <%= f.input :level %>
                 <%= f.input :years_of_experience %>
                 <div class="modal-footer">
-                  <%= f.submit "add skill", class: "btn" %>
+                  <%= f.submit "add skill", class: "site-btn" %>
                 </div>
               <% end %>
               </div>
@@ -142,7 +142,7 @@
           </div>
         </div>
  <!-- add skillmodal button -->
-        <button type="button" class="btn-modal btn-primary" data-toggle="modal" data-target="#addSkillModal">Add</button>
+        <button type="button" class="site-btn" data-toggle="modal" data-target="#addSkillModal">Add</button>
       </div>
     </div>
   </section>
@@ -159,7 +159,7 @@
         <div class="pr-project-card-body">
           <h2><%= project.title %></h2>
           <p><%= project.description %></p>
-          <button type="button" class="btn-modal btn-primary" data-toggle="modal" data-target="#editProjectModal<%= project.id %>">Edit</button>
+          <button type="button" class="icon-btn" data-toggle="modal" data-target="#editProjectModal<%= project.id %>"><i class="fa fa-edit"></i></button>
         </div>
         <div class="pr-project-card-img">
           <%= cl_image_tag project.photo.key, class: 'pr-project-card-img' %>
@@ -183,7 +183,7 @@
                     <%= f.input :title %>
                     <%= f.input :description %>
                     <%= f.input :photo, as: :file %>
-                    <%= f.submit "edit project", class: "btn" %>
+                    <%= f.submit "Update", class: "site-btn" %>
                   <% end %>
                 </div>
               </div>
@@ -192,7 +192,7 @@
         </div>
       <% end %>
 
-      <button type="button" class="btn-modal btn-primary" data-toggle="modal" data-target="#addProjectModal">Add</button>
+      <button type="button" class="site-btn" data-toggle="modal" data-target="#addProjectModal">Add</button>
 
     </div>
 
@@ -211,7 +211,7 @@
                 <%= f.input :description %>
                 <%= f.input :photo, as: :file %>
                 <div class="modal-footer">
-                  <%= f.submit "add project", class: "btn" %>
+                  <%= f.submit "add project", class: "site-btn" %>
                 </div>
               <% end %>
           </div>
@@ -240,7 +240,7 @@
             <h2><%= experience.summary %></h2>
           </div>
 
-          <button type="button" class="btn-modal btn-primary" data-toggle="modal" data-target="#editExperienceModal<%= experience.id %>">Edit</button>
+          <button type="button" class="icon-btn" data-toggle="modal" data-target="#editExperienceModal<%= experience.id %>"><i class="fa fa-edit"></i></button>
 
         </div>
 


### PR DESCRIPTION
Updated styling so that there is a now a css class called .site-btn which has been used for the buttons on the profile page. 

Added a class called .icon-btn to be used for the edit icon and delete icon on profile.

Changed the edit button to the icon.

changed the home page button css name to home-btn. This can be restyled later. 